### PR TITLE
fix: Waydroid Guide Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5735,7 +5735,7 @@
 												<div class="column mcb-column mcb-item-twr0fdvf four-fifth laptop-four-fifth tablet-four-fifth mobile-one column_column">
 													<div class="mcb-column-inner mfn-module-wrapper mcb-column-inner-twr0fdvf mcb-item-column-inner">
 														<div class="column_attr mfn-inline-editor clearfix">
-															<p>Waydroid brings the Android apps and games you love to Bazzite, working side by side with your other Linux applications. Visit our <a href="https://universal-blue.discourse.group/t/bazzite-waydroid-setup-guide/32" target="_blank">Waydroid setup guide</a> for more information.</p>
+															<p>Waydroid brings the Android apps and games you love to Bazzite, working side by side with your other Linux applications. Visit our <a href="https://universal-blue.discourse.group/docs?topic=32" target="_blank">Waydroid setup guide</a> for more information.</p>
 														</div>
 													</div>
 												</div>


### PR DESCRIPTION
It's already the correct link, but I'd rather the "documentation" link from the "Docs" and not the thread.  Mostly because I hate how my profile picture on Discourse follows everyone on thread posts.  Plus no comments will appear even if there isn't any right now.