### PR TITLE
Steam Deck OLED changes to reflect current state

### DIFF
--- a/index.html
+++ b/index.html
@@ -6436,7 +6436,8 @@
 																			computer while still retaining feature parity with SteamOS, including firmware and BIOS
 																			updates. There is no looking back from here onwards.<br>
 																			<br>
-																			Bazzite originally was intended for the Steam Deck as a way to layer system-level packages to the OS without turning off the read-only root filesystem.  It was also to give newer base package updates, printing support, and better security with Wayland and SELinux if used as more than a handheld gaming device.
+																			Bazzite originally was intended for the Steam Deck as a way to layer system-level packages to the OS without turning off the read-only root filesystem.  
+																			It was also to give newer base package updates, printing support, and better security with Wayland and SELinux if used as more than a handheld gaming device.
 																			yet.</p>
 																		</span>
 																		<span class="fade-transition hidden-fade gpd">

--- a/index.html
+++ b/index.html
@@ -6317,7 +6317,7 @@
 																						<option value="htpc">Home Theater PC</option>
 																					</optgroup>
 																					<optgroup label="Handhelds">
-																						<option value="steamdeck">Steam Deck 256GB+ (OLED in development)</option>
+																						<option value="steamdeck">Steam Deck 256GB+</option>
 																						<option value="legion">Lenovo Legion Go</option>
 																						<option value="ally">ASUS ROG Ally</option>
 																						<option value="gpd">GPD</option>
@@ -6436,9 +6436,7 @@
 																			computer while still retaining feature parity with SteamOS, including firmware and BIOS
 																			updates. There is no looking back from here onwards.<br>
 																			<br>
-																			The Steam Deck LCD model works perfectly. However, due to our newer kernel, we still have some issues to iron out with
-																			the OLED variant dealing with frame-rate limiting and intermittent speaker issues.
-																			Our team still rocks Bazzite on our Steam Deck OLEDs, but we can't recommend you do,
+																			Bazzite originally was intended for the Steam Deck as a way to layer system-level packages to the OS without turning off the read-only root filesystem.  It was also to give newer base package updates, printing support, and better security with Wayland and SELinux if used as more than a handheld gaming device.
 																			yet.</p>
 																		</span>
 																		<span class="fade-transition hidden-fade gpd">


### PR DESCRIPTION
Can change this anyway you like, but I think the OLED is now out of development outside of an installer issue... which i forgot to mention but is also on the guide.  Change this anyway you like.