### PR TITLE
[proposal]: remove faq link for Bazzite Resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -5984,7 +5984,7 @@
 												<div class="mcb-wrap-background-overlay"></div>
 												<div class="column mcb-column mcb-item-d44ed4ac2 one laptop-one tablet-one mobile-one column_heading">
 													<div class="mcb-column-inner mfn-module-wrapper mcb-column-inner-d44ed4ac2 mcb-item-heading-inner">
-														<h5 class="title">Discourse <a href="https://faq.bazzite.gg/" target="_blank" title="Frequently asked questions"><i class="link-faq fas fa-question"></i></a></h5>
+														<h5 class="title">Discourse <a href="https://universal-blue.discourse.group/docs?topic=8" target="_blank" title="Bazzite Resources"><i class="link-faq fas fa-question"></i></a></h5>
 													</div>
 												</div>
 												<div class="column mcb-column mcb-item-8444d3c36 one laptop-one tablet-one mobile-one column_column">


### PR DESCRIPTION
Links to: https://universal-blue.discourse.group/docs?topic=8 instead of the FAQ on the Discourse forums.

perhaps faq.bazzite.gg isn't really needed since its part of the documentation.