### PR TITLE
Add OneXPlayer to hardware list

### DIFF
--- a/content/themes/betheme-child/script68.js
+++ b/content/themes/betheme-child/script68.js
@@ -270,7 +270,7 @@ jQuery(document).ready(function() {
   });
 
   const desktopHardware = ['desktop', 'laptop', 'framework', 'htpc', 'asus', 'virtualmachine'];
-  const handheldHardware = ['steamdeck', 'ally', 'legion', 'gpd', 'ayn', 'handheld'];
+  const handheldHardware = ['steamdeck', 'ally', 'legion', 'gpd', 'ayn', 'handheld', 'onexplayer'];
   const hhdHardware = ['ally', 'legion', 'gpd', 'ayn', 'handheld'];
   const valveHardware = ['steamdeck'];
   const noGamemodeHardware = ['nvidia', 'nvidia-open', 'old-intel', 'virtualmachine', 'framework'];

--- a/index.html
+++ b/index.html
@@ -6753,6 +6753,7 @@
 																						<option value="ally">ASUS ROG Ally & Ally X</option>
 																						<option value="gpd">GPD</option>
 																						<option value="ayn">AYN</option>
+																						<option value="onexplayer">OneXPlayer</option>
 																						<option value="handheld">Other Handheld PC</option>
 																					</optgroup>
 																					<optgroup label="Laptops">
@@ -6886,6 +6887,10 @@
 																			With a great high resolution screen, controls that feel great, and sick looking RGB handles, there's a lot to love. We offer RGB control out-of-the-box, and the handheld experience you would expect with such a handheld. We have verified support for the Loki Max, but if you own one of the other variants then get in touch with us.
 																			We will make sure the next Bazzite version has great support for your unit too.</p>
 																		</span>
+																		<span class="fade-transition hidden-fade onexplayer">
+																			<h3>OneXPlayer</h3>
+																			<p>Bazzite now supports almost all recent OneXPlayer devices including the X1 (AMD), X1 Mini, OneXFly variants, and Mini Pro</p>
+																		</span>
 																		<span class="fade-transition hidden-fade htpc">
 																			<h3>Home Theater PCs</h3>
 																			<p>What makes Bazzite great for handhelds transfers over to Home Theater PCs. Enjoy the PC gaming console-like experience that a setup like that should have from the comfort of your couch. Feel free to bump up the frame-rate and resolution, without the power limitations of a handheld.<br>
@@ -6924,7 +6929,7 @@
 																		</span>
 																		<span class="fade-transition hidden-fade handheld">
 																			<h3>Other Handheld PCs <a href="https://docs.bazzite.gg/Handheld_and_HTPC_edition/Steam_Gaming_Mode/index.html" aria-label="Alternative Handheld PCs" target="_blank"><i class="fa-solid fa-link"></i></a></h3>
-																			<p><strong>Note</strong>: A few Ayaneo and OneXPlayer handhelds have been confirmed to boot Bazzite, but are plagued by missing driver support for Linux.<br>
+																			<p><strong>Note</strong>: A few Ayaneo handhelds have been confirmed to boot Bazzite, but are plagued by missing driver support for Linux.<br>
 																			<br>
 																			If your handheld hardware is not listed, then you can still give Bazzite a try with our Handheld/HTPC image.<br>
 																			<br>


### PR DESCRIPTION
Bazzite now supports the OneXPlayer, adjusting the website to website to reflect this change.