### PR TITLE
chore: second image changelog not rendering correctly

### DIFF
--- a/content/themes/betheme-child/script99.js
+++ b/content/themes/betheme-child/script99.js
@@ -403,7 +403,7 @@ jQuery(document).ready(function() {
             break;
           }
 
-          changelogs += '# ' + e.name + '\r\n';
+          changelogs += '\r\n# ' + e.name + '\r\n';
           changelogs += e.body;
           count += 1;
         };


### PR DESCRIPTION
If there are multiple change logs rendered on the website the second one is not getting rendered correctly and all the text is on a single line at the end, so we getting a really long scrollbar
![image](https://github.com/user-attachments/assets/6a3ad531-b600-4ca0-9a56-a0ad31b0b8bf)
With this change the second change log is rendering correctly
![image](https://github.com/user-attachments/assets/d831eca4-86e5-423a-89e2-173a96730843)
