### PR TITLE
chore: update desktop/laptop dual-boot video

### DIFF
--- a/index.html
+++ b/index.html
@@ -7222,7 +7222,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 															<iframe loading="lazy" width="560" height="315" data-src="https://www.youtube-nocookie.com/embed/45P3hlvq8jk?si=nVVk2qqnWXK4xKPT" title="Bazzite Dualboot Tutorial" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 														</div>
 														<div class="fade-transition hidden-fade desktop laptop framework htpc">
-															<iframe loading="lazy" width="560" height="315" data-src="https://www.youtube-nocookie.com/embed/pbxM_1ZJCCc?si=vHqRQ4D_CmUtycRy" title="How to dual-boot Windows 11 and Bazzite (new version)" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+															<iframe loading="lazy" width="560" height="315" data-src="https://www.youtube-nocookie.com/embed/JxPsKhJGTrs?si=-cHJ7uENdKo41ji6" title="How to dual-boot Windows 11 and Bazzite (new version)" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 														</div>
 													</div>
 												</div>


### PR DESCRIPTION
Added a section to the desktop/laptop dual-boot guide to include a missing section on how to boot Windows. Unfortunately, you cannot edit existing videos, so I have to upload a new video