### PR TITLE
Add verification checksum button for the live ISO download

### DIFF
--- a/content/themes/betheme-child/script106.js
+++ b/content/themes/betheme-child/script106.js
@@ -632,6 +632,7 @@ jQuery(document).ready(function() {
       jQuery('.button-liveiso').attr('href', 'https://download.bazzite.gg/' + imagename + '-stable-live.iso');
       jQuery('.button-torrent').attr('href', getTorrentURL(imagename));
       jQuery('.sha256').attr('href', 'https://download.bazzite.gg/' + imagename + '-stable-amd64.iso-CHECKSUM');
+      jQuery('.sha256-liveiso').attr('href', 'https://download.bazzite.gg/' + imagename + '-stable-live.iso-CHECKSUM');
       jQuery('.ghcr-details').attr('href', 'https://ghcr.io/ublue-os/' + imagename);
 
       //Show Videos

--- a/content/themes/betheme-child/style251.css
+++ b/content/themes/betheme-child/style251.css
@@ -1231,18 +1231,21 @@ d-topics-list > iframe {
   margin-top: 2px;
 }
 
-.sha256 {
+.sha256,
+.sha256-liveiso {
   position: absolute;
   margin-top: 13px;
   margin-left: 15px;
 }
 
-.sha256 .fa-file {
+.sha256 .fa-file,
+.sha256-liveiso .fa-file {
   color: #ccc;
   font-size: 25px;
 }
 
-.sha256 .fa-check {
+.sha256 .fa-check,
+.sha256-liveiso .fa-check {
   color: #262626;
   position: absolute;
   font-size: 14px;
@@ -1250,7 +1253,8 @@ d-topics-list > iframe {
   left: 3px;
 }
 
-.sha256:hover .fa-file {
+.sha256:hover .fa-file, 
+.sha256-liveiso:hover .fa-file {
   color: #fff;
 }
 
@@ -1599,7 +1603,8 @@ d-topics-list > iframe {
     max-width: inherit;
   }
 
-  .sha256 {
+  .sha256,
+  .sha256-liveiso {
     margin-top: 16px;
   }
 
@@ -1706,7 +1711,8 @@ d-topics-list > iframe {
   }
 
   .ghcr-details,
-  .sha256 {
+  .sha256,
+  .sha256-liveiso {
     display: none;
     visibility: hidden;
   }

--- a/index.html
+++ b/index.html
@@ -7202,6 +7202,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 																	<i class="fas fa-flask"></i>
 																</span>
 															</a>
+															<a class="sha256-liveiso" title="Verify Live ISO (SHA256)"><i class="fas fa-file"><i class="fas fa-check"></i></i></a>
 														</div>
 														<div class="button-torrent-container" style="display:none!important;visibility:hidden!important;">
 															<a class="button-torrent button has-icon button_left" target="_blank" href="https://fosstorrents.com/distributions/bazzite/">


### PR DESCRIPTION
Hi, I was grabbing the live ISO file from the main site and wanted to verify it's checksum when I noticed the button was missing for the "Live ISO" download button, then I noticed it actually existed on the server "https://download.bazzite.gg/bazzite-stable-live.iso-CHECKSUM", so I decided to add it myself making it easily accessible for future users.

<img width="595" height="346" alt="image" src="https://github.com/user-attachments/assets/666aadb5-40cc-4aa3-a328-27969eff9396" />

Let me know if any other changes are required or if there was a specific reason this wasn't there in the first place.