### PR TITLE
Fix sha256 of live iso not redirecting to the correct checksum download

### DIFF
--- a/index.html
+++ b/index.html
@@ -7205,7 +7205,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 																	<i class="fas fa-flask"></i>
 																</span>
 															</a>
-															<a class="sha256" title="Verify (SHA256)"><i class="nerd-icon-inline">󰈖</i></a>
+															<a class="sha256-liveiso" title="Verify (SHA256)"><i class="nerd-icon-inline">󰈖</i></a>
 														</div>
 														<div class="button-torrent-container" style="height:0px!important;margin:0px!important;display:none!important;visibility:hidden!important;">
 															<a class="button-torrent button has-icon button_left" target="_blank" href="https://fosstorrents.com/distributions/bazzite/">


### PR DESCRIPTION
Currently, live iso checksum download would download the regular checksum (of the non live iso). This PR changes the class of the download button from `sha256` to `sha256-liveiso`, which should hopefully link to the correct checksum download.