### PR TITLE
fix: hide live iso and live iso hash download buttons for asus iso images

### DIFF
--- a/content/themes/betheme-child/script111.js
+++ b/content/themes/betheme-child/script111.js
@@ -635,6 +635,15 @@ jQuery(document).ready(function() {
       jQuery('.sha256-liveiso').attr('href', 'https://download.bazzite.gg/' + imagename + '-stable-live.iso-CHECKSUM');
       jQuery('.ghcr-details').attr('href', 'https://ghcr.io/ublue-os/' + imagename);
 
+      // Hide live ISO button and checksum for ASUS hardware (no live ISO available)
+      if (asusHardware.includes(hardware)) {
+        jQuery('.button-liveiso').hide();
+        jQuery('.sha256-liveiso').hide();
+      } else {
+        jQuery('.button-liveiso').show();
+        jQuery('.sha256-liveiso').show();
+      }
+
       //Show Videos
       jQuery('.video-container > .fade-transition').removeClass('shown-fade').addClass('hidden-fade');
       jQuery('.video-container > .fade-transition.' + hardware).removeClass('hidden-fade').addClass('shown-fade');


### PR DESCRIPTION
There are no live ISO files for any of the asus images as mentioned in https://github.com/ublue-os/bazzite/issues/3344. This change will just hide the live iso download button and sha256 hash link for the live iso if any of the asus images are selected.

I think that https://download.bazzite.gg/bazzite-deck-nvidia-gnome-stable-live.iso is probably a live ISO that was accidentally missed so I left that one alone.