### PR TITLE
fix: remove bazzite-deck-deck

### DIFF
--- a/content/themes/betheme-child/script111.js
+++ b/content/themes/betheme-child/script111.js
@@ -609,6 +609,10 @@ jQuery(document).ready(function() {
       imagename = imagename.replace('bazzite', 'bazzite-deck')
     }
 
+    // It's possible to get bazzite-deck-deck if the user selects anything with gamemode and then changes
+    // hardware selection to handheld. This fixes that.
+    imagename = imagename.replace('deck-deck', 'deck');
+
     if (gpuVendor === "amd" && steamGameMode === 'yes' && !gamemodeHardware.includes(hardware) && !apuHardware.includes(hardware) && hardware != 'virtualmachine') {
       jQuery('#image-builder .gamemode-noigpu').removeClass('hidden-fade').addClass('shown-fade');
     } else {


### PR DESCRIPTION
If you select any any hardware that lets you select gamemode then you switch to a handheld you get bazzite-deck-deck and bazzite-deck-deck-gnome etc. This is a hacky fix to get rid of that possibility 