### PR TITLE
Update desktop dual-boot video guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -7288,7 +7288,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 															<iframe loading="lazy" width="560" height="315" data-src="https://www.youtube-nocookie.com/embed/45P3hlvq8jk?si=nVVk2qqnWXK4xKPT" title="Bazzite Dualboot Tutorial" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 														</div>
 														<div class="fade-transition hidden-fade desktop laptop framework htpc">
-															<iframe loading="lazy" width="560" height="315" data-src="https://www.youtube-nocookie.com/embed/JxPsKhJGTrs?si=-cHJ7uENdKo41ji6" title="How to dual-boot Windows 11 and Bazzite (new version)" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+															<iframe loading="lazy" width="560" height="315" data-src="https://www.youtube-nocookie.com/embed/KAt49B6rSFI?si=3QMfFdRfDYNBObiY" title="How to dual-boot Windows 11 and Bazzite" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 														</div>
 													</div>
 												</div>


### PR DESCRIPTION
I've updated my dual-boot video guide. This version uses Fedora Media Writer, which appears to cause the fewest issues. The old guide still used Ventoy, but this is no longer supported. I think I've also addressed all the common issues users might encounter.  