### PR TITLE
website: add tabbed menu for installation methods, add bruh for Bazzite users

### DIFF
--- a/content/themes/betheme-child/script116.js
+++ b/content/themes/betheme-child/script116.js
@@ -670,3 +670,26 @@ jQuery(document).ready(function() {
     }
   });
 });
+function openResult(evt, imgName) {
+  // Declare all variables
+  var i, tabcontent, tablinks;
+
+  // Get all elements with class="tabcontent" and hide them
+  tabcontent = document.getElementsByClassName("tabcontent");
+  for (i = 0; i < tabcontent.length; i++) {
+    tabcontent[i].style.display = "none";
+  }
+
+  // Get all elements with class="tablinks" and remove the class "active"
+  tablinks = document.getElementsByClassName("tablinks");
+  for (i = 0; i < tablinks.length; i++) {
+    tablinks[i].className = tablinks[i].className.replace(" active", "");
+  }
+
+  // Show the current tab, and add an "active" class to the button that opened the tab
+  document.getElementById(imgName).style.display = "block";
+  evt.currentTarget.className += " active";
+
+}
+
+  document.getElementById("defaultOpen").click();

--- a/content/themes/betheme-child/style262.css
+++ b/content/themes/betheme-child/style262.css
@@ -1860,4 +1860,11 @@ d-topics-list > iframe {
   .mcb-wrap-inner-f6578f479 .content-container .title {
     margin-top: 100px;
   }
+  .tab button.active {
+    background-color: #1542a6;
+  }
+   button.tablinks.active {
+    background-color: #1542a6;
+  }
+
 }

--- a/content/themes/betheme-child/style262.css
+++ b/content/themes/betheme-child/style262.css
@@ -1861,11 +1861,25 @@ d-topics-list > iframe {
     margin-top: 100px;
   }
   .tab button.active {
-    background-color: #1542a6;
+  background-color: #9d2af6;
   }
-   button.tablinks.active {
-   /* not currently working*/
-    background-color: #1542a6;
-  }
-
 }
+.tab button.active,
+  button.tablinks.active {
+        background-image: linear-gradient(130deg, rgb(5, 70, 173) 0%, rgb(138, 43, 226) 100%);
+            background-color: rgb(5, 70, 173) !important;
+            overflow: visible;
+            transform-style: preserve-3d;
+            box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.01);
+            transition: background-color 0.1s ease-in-out;
+  }
+  .tab button {
+    background-color: #000 !important;
+    float: left;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    padding: 14px 16px;
+    transition: 0.3s;
+  }
+background: #5643b4

--- a/content/themes/betheme-child/style262.css
+++ b/content/themes/betheme-child/style262.css
@@ -1864,6 +1864,7 @@ d-topics-list > iframe {
     background-color: #1542a6;
   }
    button.tablinks.active {
+   /* not currently working*/
     background-color: #1542a6;
   }
 

--- a/index.html
+++ b/index.html
@@ -7273,8 +7273,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														<br>
 														<span class="command-header">
 															<h3>Existing <a href="https://fedoraproject.org/atomic-desktops/" target="_blank">Fedora Atomic Desktop</a> Users</h3>
-															Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
-															<br>
+															<p>Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br></p>
 															You may rebase to <span class="image-name"></span> with this command:
 														</span>
 														<span class="command">rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/<span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>
@@ -7286,6 +7285,8 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 															<strong>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</strong><br>
 															<br>
 															Your flatpaks and flatpak remotes will not be changed during the rebase process. Once rebased, you can optionally install Bazzite's default flatpaks by running the following in a terminal:<br><span class="command" style="margin-top:5px;">ujust _install-system-flatpaks</span>
+															<br><br>
+															<p>Once everything is set up properly, then you should rebase from the unsigned image to the signed image for security reasons, so enter this command in the host terminal:</p><span class="command">rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/<span class="image-name"></span>:stable</span>
 														</span>
 													</div>
 													<div id="Bazzite" class="tabcontent" class="rebase" >
@@ -7293,7 +7294,6 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														<span class="command-header">
 														<h3>Existing Bazzite users</h3>
 														<p>Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br></p>
-														<br>
 														You may rebase to <span class="image-name"></span> with this command:
 														</span>
 														<span class="command">brh rebase <span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>

--- a/index.html
+++ b/index.html
@@ -7282,12 +7282,12 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														<span class="fine-print">
 															If you're using secure boot, follow our <strong><a href="https://docs.bazzite.gg/General/Installation_Guide/secure_boot/" target="_blank">secure boot documentation</a></strong> before rebasing. You may also follow the <a href="https://www.youtube.com/watch?v=Vs4cneBW5ck" target="_blank">rebasing video guide</a>.<br>
 															<br>
-															<b>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</b><br>
+															<strong>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</strong><br>
 															<br>
 															Your flatpaks and flatpak remotes will not be changed during the rebase process. Once rebased, you can optionally install Bazzite's default flatpaks by running the following in a terminal:<br><span class="command" style="margin-top:5px;">ujust _install-system-flatpaks</span>
 														</span>
 													</div>
-													<div id="Bazzite" class="tabcontent" class="brh" >
+													<div id="Bazzite" class="tabcontent" class="rebase" >
 														<h3>Existing Bazzite users</h3>
 														Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
 														<br>
@@ -7297,7 +7297,8 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														brh rebase <span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>
 														<br>
 														<br>
-														<strong>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</strong><br>
+														<span class="fine-print">
+															<strong>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</strong><br> </span>
 													</div>
 													<div class="video-container">
 														<div class="fade-transition hidden-fade gpd">

--- a/index.html
+++ b/index.html
@@ -7270,11 +7270,12 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														View all <a href="https://docs.bazzite.gg/" target="_blank">Bazzite documentation</a>.</span>
 													</div>
 													<div id="Fedora" class="tabcontent" class="rebase" >
+														<br>
 														<span class="command-header">
 															<h3>Existing <a href="https://fedoraproject.org/atomic-desktops/" target="_blank">Fedora Atomic Desktop</a> Users</h3>
 															Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
 															<br>
-															You may rebase to Bazzite with this command:
+															You may rebase to <span class="image-name"></span> with this command:
 														</span>
 														<span class="command">rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/<span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>
 														<br>
@@ -7288,13 +7289,14 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														</span>
 													</div>
 													<div id="Bazzite" class="tabcontent" class="rebase" >
+														<br>
+														<span class="command-header">
 														<h3>Existing Bazzite users</h3>
-														Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
+														<p>Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br></p>
 														<br>
 														You may rebase to <span class="image-name"></span> with this command:
-														<br>
-														<span class="command">
-														brh rebase <span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>
+														</span>
+														<span class="command">brh rebase <span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>
 														<br>
 														<br>
 														<span class="fine-print">

--- a/index.html
+++ b/index.html
@@ -5295,7 +5295,7 @@
 				}
 			}
 		</style>
-		<link rel='stylesheet' id='style-css' href='content/themes/betheme-child/style261.css' type='text/css' media='all' />
+		<link rel='stylesheet' id='style-css' href='content/themes/betheme-child/style262.css' type='text/css' media='all' />
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" id="jquery-core-js"></script>
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.5.2/jquery-migrate.min.js" id="jquery-migrate-js"></script>
 		<link rel="canonical" href="https://bazzite.gg/" />
@@ -7232,7 +7232,12 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 													</div>
 												</div>
 												<div id="image-builder-result" class="fade-transition hidden-fade">
-													<div class="iso-selection">
+													<div class="tab">
+														<button class="tablinks" onclick="openResult(event, 'New')" id="defaultOpen">New Users</button>
+														<button class="tablinks" onclick="openResult(event, 'Bazzite')">Existing Bazzite Users</button>
+														<button class="tablinks" onclick="openResult(event, 'Fedora')">Existing Fedora Atomic Users</button>
+													</div>
+													<div id="New" class="tabcontent" class="iso-selection">
 														<h3>New Users</h3>
 														<div class="button-liveiso-container">
 															<a class="button-liveiso glow-effect button has-icon button_right">
@@ -7264,10 +7269,10 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														<span class="fine-print">View the <a href="https://docs.bazzite.gg/General/Installation_Guide/index.html" target="_blank">Bazzite initial setup guide</a>.<br>
 														View all <a href="https://docs.bazzite.gg/" target="_blank">Bazzite documentation</a>.</span>
 													</div>
-													<div class="rebase">
+													<div id="Fedora" class="tabcontent" class="rebase" >
 														<span class="command-header">
 															<h3>Existing <a href="https://fedoraproject.org/atomic-desktops/" target="_blank">Fedora Atomic Desktop</a> Users</h3>
-															It is recommended to remove any layered packages before proceeding with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
+															Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
 															<br>
 															You may rebase to Bazzite with this command:
 														</span>
@@ -7277,10 +7282,22 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 														<span class="fine-print">
 															If you're using secure boot, follow our <strong><a href="https://docs.bazzite.gg/General/Installation_Guide/secure_boot/" target="_blank">secure boot documentation</a></strong> before rebasing. You may also follow the <a href="https://www.youtube.com/watch?v=Vs4cneBW5ck" target="_blank">rebasing video guide</a>.<br>
 															<br>
-															<strong>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</strong><br>
+															<b>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</b><br>
 															<br>
 															Your flatpaks and flatpak remotes will not be changed during the rebase process. Once rebased, you can optionally install Bazzite's default flatpaks by running the following in a terminal:<br><span class="command" style="margin-top:5px;">ujust _install-system-flatpaks</span>
 														</span>
+													</div>
+													<div id="Bazzite" class="tabcontent" class="brh" >
+														<h3>Existing Bazzite users</h3>
+														Before proceeding, it is recommended to remove any layered packages with this command:<br><span class="command" style="margin-top:5px;">rpm-ostree reset</span><br>
+														<br>
+														You may rebase to <span class="image-name"></span> with this command:
+														<br>
+														<span class="command">
+														brh rebase <span class="image-name"></span>:stable</span><a class="ghcr-details" style="text-decoration: none;" title="View details on the GitHub Container registry" target="_blank"><i style="padding-left:7px;top:3px;position:relative;font-size:18px;" class="nerd-icon-inline"></i></a>
+														<br>
+														<br>
+														<strong>It's recommended by upstream that you stick to the same desktop environment as your current install when rebasing.</strong><br>
 													</div>
 													<div class="video-container">
 														<div class="fade-transition hidden-fade gpd">
@@ -7413,7 +7430,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 		<script type="text/javascript" src="content/themes/betheme/js/scripts2.js" id="mfn-scripts-js"></script>
 		<script type="text/javascript" src="content/themes/betheme/js/plugins/imagesloaded.min.js%3Fver=27.3.5" id="mfn-imagesloaded-js"></script>
 		<script type="text/javascript" src="content/themes/betheme/js/plugins/slick.min.js?ver=27.3.5" id="mfn-slick-js"></script>
-		<script type="text/javascript" src="content/themes/betheme-child/script114.js" id="script-js" defer></script>
+		<script type="text/javascript" src="content/themes/betheme-child/script116.js" id="script-js" defer></script>
 		<script type="text/javascript" src="content/themes/betheme/assets/lottie/lottie-player.js" id="mfn-lottie-player-js" defer></script>
 		<script type="text/javascript" src="content/themes/betheme-child/lottie.js" id="lottie" defer></script>
 		<script type="text/javascript" src="https:///universal-blue.discourse.group/javascripts/embed-topics.js" id="discourse-js" defer></script>


### PR DESCRIPTION
This should hopefully reduce user confusion and prevent Bazzite users from rebasing to Unverified by accident

add tabbed menu to switch between 3 different installation methods:
1) new user
2) (new) Bazzite: offer brh command to rebase
3) Fedora Atomic


switching between the tabs work properly
default tab: new users
<img width="603" height="418" alt="Screenshot_20260201_002319" src="https://github.com/user-attachments/assets/3f395698-d555-4c77-a28a-f536ed19ced7" />
<img width="959" height="418" alt="Screenshot_20260201_002324" src="https://github.com/user-attachments/assets/76d2afc3-a91c-43f9-855d-58d017ff2aea" />
<img width="1304" height="691" alt="Screenshot_20260201_002337" src="https://github.com/user-attachments/assets/59fe9912-0c59-4de5-a610-29bf0714bbe9" />
