### PR TITLE
fix(docs): Fix link to Nvidia issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -7076,7 +7076,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 																			<span class="picker-message red">When using Steam Gaming Mode in a virtual machine, you <strong>must</strong> pass-through a GPU.</span>
 																		</div>
 																		<div class="gamemode-beta fade-transition hidden-fade">
-																			<span class="picker-message red">Steam Gaming Mode support is available for your hardware in beta, but <a href="https://docs.bazzite.gg/Handheld_and_HTPC_edition/quirks/#nvidia-exclusive-issues" target="_blank">multiple known issues exist in these builds</a>. Please note that the majority of bugs cannot be fixed except by your GPU manufacturer.</span>
+																			<span class="picker-message red">Steam Gaming Mode support is available for your hardware in beta, but <a href="https://docs.bazzite.gg/Handheld_and_HTPC_edition/quirks/#nvidia-gpu-exclusive-issues-with-steam-gaming-mode" target="_blank">multiple known issues exist in these builds</a>. Please note that the majority of bugs cannot be fixed except by your GPU manufacturer.</span>
 																		</div>
 																		<div class="gamemode-noigpu fade-transition hidden-fade">
 																			<span class="picker-message red">Some devices with two AMD GPUs (iGPU and dGPU) cause gamescope to be unable to detect your display resulting in a black screen. If you are affected, use an image without Steam Gaming Mode or disable your iGPU. <a href="https://github.com/ValveSoftware/gamescope/issues/1469" target="_blank">See this issue</a> for more information.</span>


### PR DESCRIPTION
Link goes to missing or renamed #nvidia-exclusive-issues URL fragment; #nvidia-gpu-exclusive-issues-with-steam-gaming-mode is the current and working fragment