### PR TITLE
Website: Improve Website UX by making the live iso the primary option

### DIFF
--- a/content/themes/betheme-child/style268.css
+++ b/content/themes/betheme-child/style268.css
@@ -557,12 +557,6 @@ code {
   color: #fff;
 }
 
-.button-torrent,
-.button-liveiso {
-  background-image: none;
-  background: #5643b4 !important;
-}
-
 .button-torrent .button_icon {
   margin-top: -3px;
   margin-bottom: -3px;
@@ -1286,7 +1280,6 @@ d-topics-list > iframe {
 
 .sha256,
 .sha256-liveiso {
-  position: absolute;
   margin-top: 13px;
   margin-left: 15px;
 }
@@ -1919,3 +1912,10 @@ d-topics-list > iframe {
     margin-top: 100px;
   }
 }
+.button-download {
+    margin-left: 20px;
+    padding: 5px!important;
+    font-size: 10px!important;
+    background: none!important;
+}
+

--- a/index.html
+++ b/index.html
@@ -5295,7 +5295,7 @@
 				}
 			}
 		</style>
-		<link rel='stylesheet' id='style-css' href='content/themes/betheme-child/style267.css' type='text/css' media='all' />
+		<link rel='stylesheet' id='style-css' href='content/themes/betheme-child/style268.css' type='text/css' media='all' />
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" id="jquery-core-js"></script>
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.5.2/jquery-migrate.min.js" id="jquery-migrate-js"></script>
 		<link rel="canonical" href="https://bazzite.gg/" />
@@ -7247,8 +7247,9 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 															<a class="sha256-liveiso" title="Verify (SHA256)"><i class="nerd-icon-inline">󰈖</i></a>
 														</div>
 														<div class="button-download-container">
-															<a class="button-download button has-icon button_left" target="_blank">
-																<span class="button_label">Download <span style="white-space:nowrap;"><span class="bazzite-name image-name"></span> Legacy ISO</span>
+															<a class="button-download  has-icon button_left" target="_blank">
+																<span class="button_label">Download <span style="white-space:nowrap;"><span class="bazzite-name image-name"></span> Legacy installer</span>
+
 																</span>
 																<span class="button_icon">
 																	<i class="fas fa-person-cane"></i>
@@ -7264,6 +7265,8 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 																<span class="button_label">FOSS Torrents</span>
 															</a>
 														</div>
+														<span class="fine-print">The Legacy installer will be phased out soon, using the regular installer is recommended.</span>
+														<br><br>
 														<span class="fine-print">View the <a href="https://docs.bazzite.gg/General/Installation_Guide/index.html" target="_blank">Bazzite initial setup guide</a>.<br>
 														View all <a href="https://docs.bazzite.gg/" target="_blank">Bazzite documentation</a>.</span>
 													</div>


### PR DESCRIPTION
- add the gradient from the legacy download button to the regular button
- made the legacy download button into a link (visually), removed the background, made font smaller, reduced padding, in an effort to make it stand out less
- fix the position of the verify checksum
- renamed 'legacy iso' to 'legacy installer' to make it more clear what it is
- added disclaimer that legacy installer is not recommended

<img width="730" height="442" alt="Screenshot_20260227_231745" src="https://github.com/user-attachments/assets/bd14d537-086e-4c57-aef0-4090b4d783c2" />
