### PR TITLE
Website: update the website to be inline with the docs (ujust verify-image)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7287,7 +7287,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 															<br>
 															Your flatpaks and flatpak remotes will not be changed during the rebase process. Once rebased, you can optionally install Bazzite's default flatpaks by running the following in a terminal:<br><span class="command" style="margin-top:5px;">ujust _install-system-flatpaks</span>
 															<br><br>
-															<p>Once everything is set up properly, then you should rebase from the unsigned image to the signed image for security reasons, so enter this command in the host terminal:</p><span class="command">rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/<span class="image-name"></span>:stable</span>
+															<p>Once everything is set up properly, then you should rebase from the unsigned image to the signed image for security reasons, so enter this command in the host terminal:</p><span class="command">ujust verify-image</span>
 														</span>
 													</div>
 													<div id="Bazzite" class="tabcontent" class="rebase" >


### PR DESCRIPTION
we have a ujust for verifying the image now, much simpler than rpm-ostree rebase