### PR TITLE
fix: revert to old style for picker messages other than deck-nvida

### DIFF
--- a/content/themes/betheme-child/style270.css
+++ b/content/themes/betheme-child/style270.css
@@ -841,6 +841,11 @@ code {
 }
 
 .picker-message.red {
+  color: #ff8484;
+  font-weight: 600;
+}
+
+.picker-message.red-deck-nvidia {
   color: #f50000;
   font-weight: 1000;
   font-size: 25px;

--- a/index.html
+++ b/index.html
@@ -5295,7 +5295,7 @@
 				}
 			}
 		</style>
-		<link rel='stylesheet' id='style-css' href='content/themes/betheme-child/style269.css' type='text/css' media='all' />
+		<link rel='stylesheet' id='style-css' href='content/themes/betheme-child/style270.css' type='text/css' media='all' />
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" id="jquery-core-js"></script>
 		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.5.2/jquery-migrate.min.js" id="jquery-migrate-js"></script>
 		<link rel="canonical" href="https://bazzite.gg/" />
@@ -7076,7 +7076,7 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 																			<span class="picker-message red">When using Steam Gaming Mode in a virtual machine, you <strong>must</strong> pass-through a GPU.</span>
 																		</div>
 																		<div class="gamemode-beta fade-transition hidden-fade">
-																			<span class="picker-message red">PLEASE NOTE THAT USING GAMING MODE WITH NVIDIA HARDWARE CURRENTLY HAS SEVERE GRAPHICAL ISSUES. MOST OF THESE ISSUES ARE OUTSIDE BAZZITE'S CONTROL AND CAN ONLY BE FIXED BY NVIDIA.<br><br>IT IS RECOMMENDED TO USE A DESKTOP IMAGE INSTEAD.</span>
+																			<span class="picker-message red-deck-nvidia">PLEASE NOTE THAT USING GAMING MODE WITH NVIDIA HARDWARE CURRENTLY HAS SEVERE GRAPHICAL ISSUES. MOST OF THESE ISSUES ARE OUTSIDE BAZZITE'S CONTROL AND CAN ONLY BE FIXED BY NVIDIA.<br><br>IT IS RECOMMENDED TO USE A DESKTOP IMAGE INSTEAD.</span>
 																		</div>
 																		<div class="gamemode-noigpu fade-transition hidden-fade">
 																			<span class="picker-message red">Some devices with two AMD GPUs (iGPU and dGPU) cause gamescope to be unable to detect your display resulting in a black screen. If you are affected, use an image without Steam Gaming Mode or disable your iGPU. <a href="https://github.com/ValveSoftware/gamescope/issues/1469" target="_blank">See this issue</a> for more information.</span>


### PR DESCRIPTION
It looks ridiculous now on other picker messages, this PR creates a separate class for deck-nvidia

<img width="554" height="429" alt="image" src="https://github.com/user-attachments/assets/1668f7a2-b1d0-4db2-9586-2517317f2a72" />
