### PR TITLE
fix: Intel GPU clarification

### DIFF
--- a/index.html
+++ b/index.html
@@ -7036,12 +7036,12 @@ https://www.forbes.com/sites/jasonevangelho/2024/12/03/5-reasons-you-should-run-
 																					<optgroup label="Modern GPUs">
 																						<option value="amd">AMD (RX 4xx+ | AI)</option>
 																						<option value="nvidia-open">Nvidia (RTX Series | GTX 16xx Series+)</option>
-																						<option value="intel">Intel (ARC+)</option>
+																						<option value="intel">Intel (Tigerlake | ARC+)</option>
 																					</optgroup>
 																					<optgroup label="Older/Legacy GPUs">
 																						<option value="old-amd">AMD (HD/200/300/R9)</option>
 																						<option value="nvidia">Nvidia (GTX 9xx-10xx Series)</option>
-																						<option value="old-intel">Intel (UHD/HD/Iris)</option>
+																						<option value="old-intel">Intel (Skylake-Icelake)</option>
 																					</optgroup>
 																					<optgroup label="Even Older GPUs">
 																						<option disabled value>"Now this will run on my 486?"</option>


### PR DESCRIPTION
Add CPUs so we don't have "Why are games not working on my HD Graphics 4400, it says HD so that must be mine"

Would 4xxx-1xxxx be better?